### PR TITLE
We have been setting 'groupId' as the name,

### DIFF
--- a/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
+++ b/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
@@ -178,7 +178,7 @@ public class Office365ApiClient implements O365UserLookup {
     }
     private String getGroupName(Group group){
         String groupName = group.getName();
-        if(!groupName.equals(group.getDisplayName()))){
+        if(!groupName.equals(group.getDisplayName())){
             groupName = group.getDisplayName();
         }
         return groupName;

--- a/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
+++ b/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
@@ -176,17 +176,25 @@ public class Office365ApiClient implements O365UserLookup {
     protected <T> ResponseWrapper<T> invokeResponse(retrofit2.Call<T> call,boolean doMembershipRemove) throws IOException {
         return new RetroFitInvoker<T>(this, call,doMembershipRemove).invoke();
     }
+    private String getGroupName(Group group){
+        String groupName = group.getName();
+        if(!groupName.equals(group.getDisplayName()))){
+            groupName = group.getDisplayName();
+        }
+        return groupName;
+    }
     public void updateGroup(Group group){
         if (group != null) {
             logger.debug("Updating group " + group);
             try {
                 logger.debug("**** ");
                 String id = lookupO365GroupId(group);
+               String groupName = getGroupName(group);
                 if(StringUtils.isNotEmpty(id)) {
                     final ResponseWrapper response = invoke(this.service.updateGroup(id,
                             new edu.internet2.middleware.grouper.changeLog.consumer.model.Group(
                                     id,
-                                    group.getName(),
+                                    groupName,
                                     false,
                                     group.getUuid(),
                                     true,
@@ -209,11 +217,11 @@ public class Office365ApiClient implements O365UserLookup {
             logger.debug("Creating group " + group);
             try {
                 logger.debug("**** ");
-
+                String groupName = getGroupName(group);
                 final ResponseWrapper response = invoke(this.service.createGroup(
                         new edu.internet2.middleware.grouper.changeLog.consumer.model.Group(
                                 null,
-                                group.getName(),
+                                groupName,
                                 false,
                                 group.getUuid(),
                                 true,

--- a/src/test/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClientUTest.java
+++ b/src/test/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClientUTest.java
@@ -131,6 +131,7 @@ public class Office365ApiClientUTest {
     @Test
     public void testAddGroup() {
         Group group = new Group();
+        group.setDisplayNameDb("bob");
         group.setNameDb("bob");
         group.setId("id");
         edu.internet2.middleware.grouper.changeLog.consumer.model.Group model = new edu.internet2.middleware.grouper.changeLog.consumer.model.Group(


### PR DESCRIPTION
which is different than the displayName, which is what people rename.
Modifying the update to use the displayname if it differs
from the groupId.