### PR TITLE
Fix for missing group prefix and suffix

### DIFF
--- a/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
+++ b/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
@@ -196,6 +196,10 @@ public class Office365ApiClient implements O365UserLookup {
         groupName = getStemSuffix(groupName);
         return groupName;
     }
+    
+    private String getParsedGroupName(String groupName) {
+        return getStemPrefix(getStemSuffix(groupName));
+    }
 
     private String getStemPrefix(String groupName) {
         if (StringUtils.isNotEmpty(azurePrefix)){
@@ -317,6 +321,7 @@ public class Office365ApiClient implements O365UserLookup {
         logger.debug("removing group " + groupName);
         try {
             Map options = new TreeMap<>();
+            groupName = getParsedGroupName(groupName);
             options.put("$filter", "displayName eq '" + groupName + "'");
             logger.debug("filter is " + "displayName eq '" + groupName + "'");
             final ResponseWrapper response = invoke(this.service.getGroups(options));

--- a/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
+++ b/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
@@ -196,7 +196,7 @@ public class Office365ApiClient implements O365UserLookup {
         groupName = getStemSuffix(groupName);
         return groupName;
     }
-    
+
     private String getParsedGroupName(String groupName) {
         return getStemPrefix(getStemSuffix(groupName));
     }

--- a/src/test/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClientUTest.java
+++ b/src/test/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClientUTest.java
@@ -150,7 +150,7 @@ public class Office365ApiClientUTest {
 
     @Test
     public void testRemoveGroup() {
-        String groupName = "bob";
+        String groupName = "ksu:bob:ksu";
         Map options = new TreeMap<>();
         options.put("$filter", "displayName eq '" + groupName + "'");
         edu.internet2.middleware.grouper.changeLog.consumer.model.Group model = new edu.internet2.middleware.grouper.changeLog.consumer.model.Group(


### PR DESCRIPTION
Added method to append prefix and suffix to group name in removeGroup().
Updated unit test to reflect the change.