### PR TITLE
fix: Fix issue with change log consumer not deleting groups

### DIFF
--- a/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
+++ b/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ApiClient.java
@@ -198,7 +198,8 @@ public class Office365ApiClient implements O365UserLookup {
     }
 
     private String getParsedGroupName(String groupName) {
-        return getStemPrefix(getStemSuffix(groupName));
+        final String shortName = GrouperO365Utils.getShortGroupName(groupName, grouperO365FolderName.split(":").length);
+        return getStemPrefix(getStemSuffix(shortName));
     }
 
     private String getStemPrefix(String groupName) {


### PR DESCRIPTION
The name of the group needed to be truncated to the 'short' name for the group, then rest would work appropriately.  The 'short' name is basically the name of the group minus the stem that the group lives in.