### PR TITLE
Tdx 32087

### DIFF
--- a/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ChangeLogConsumer.java
+++ b/src/main/java/edu/internet2/middleware/grouper/changeLog/consumer/Office365ChangeLogConsumer.java
@@ -3,7 +3,6 @@ package edu.internet2.middleware.grouper.changeLog.consumer;
 
 import edu.internet2.middleware.grouper.*;
 import edu.internet2.middleware.grouper.app.loader.GrouperLoaderConfig;
-import edu.internet2.middleware.grouper.app.loader.OtherJobBase;
 import edu.internet2.middleware.grouper.changeLog.ChangeLogConsumerBaseImpl;
 import edu.internet2.middleware.grouper.changeLog.ChangeLogEntry;
 import edu.internet2.middleware.grouper.changeLog.ChangeLogProcessorMetadata;
@@ -55,7 +54,7 @@ public class Office365ChangeLogConsumer extends ChangeLogConsumerBaseImpl {
 
     }
 
-    public Office365ChangeLogConsumer(OtherJobBase.OtherJobInput input, String name) {
+    public Office365ChangeLogConsumer(String name) {
         // TODO: this.getConsumerName() isn't working for some reason. track down
         grouperSession = GrouperSession.startRootSession();
         initproperties(grouperSession,name);
@@ -68,17 +67,17 @@ public class Office365ChangeLogConsumer extends ChangeLogConsumerBaseImpl {
         }
     }
 
-    private void initproperties(GrouperSession grouperSession, String name) {
-        this.clientId = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired(CONFIG_PREFIX + name + ".clientId");
-        this.clientSecret = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired(CONFIG_PREFIX + name + ".clientSecret");
-        this.tenantId = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired(CONFIG_PREFIX + name + ".tenantId");
-        this.scope = GrouperLoaderConfig.retrieveConfig().propertyValueString(CONFIG_PREFIX + name + ".scope", "https://graph.microsoft.com/.default");
-        this.subdomainStem = GrouperLoaderConfig.retrieveConfig().propertyValueString(CONFIG_PREFIX + name + ".subdomainStem", "ksu:NotInLdapApplications:office365:subdomains");
-        String grouperO365FolderName = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired("changeLog.consumer." + name + ".folderWithGroups");
-        String azurePrefix = GrouperLoaderConfig.retrieveConfig().propertyValueString("changeLog.consumer." + name + ".azure.prefix");
-        String azureSuffix = GrouperLoaderConfig.retrieveConfig().propertyValueString("changeLog.consumer." + name + ".azure.suffix");
+    private void initproperties(GrouperSession grouperSession, String provisionerName) {
+        this.clientId = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired(CONFIG_PREFIX + provisionerName + ".clientId");
+        this.clientSecret = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired(CONFIG_PREFIX + provisionerName + ".clientSecret");
+        this.tenantId = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired(CONFIG_PREFIX + provisionerName + ".tenantId");
+        this.scope = GrouperLoaderConfig.retrieveConfig().propertyValueString(CONFIG_PREFIX + provisionerName + ".scope", "https://graph.microsoft.com/.default");
+        this.subdomainStem = GrouperLoaderConfig.retrieveConfig().propertyValueString(CONFIG_PREFIX + provisionerName + ".subdomainStem", "ksu:NotInLdapApplications:office365:subdomains");
+        String grouperO365FolderName = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired("changeLog.consumer." + provisionerName + ".folderWithGroups");
+        String azurePrefix = GrouperLoaderConfig.retrieveConfig().propertyValueString("changeLog.consumer." + provisionerName + ".azure.prefix");
+        String azureSuffix = GrouperLoaderConfig.retrieveConfig().propertyValueString("changeLog.consumer." + provisionerName + ".azure.suffix");
 
-        this.apiClient = new Office365ApiClient(clientId, clientSecret, tenantId, scope, name, grouperO365FolderName, azurePrefix, azureSuffix, grouperSession);
+        this.apiClient = new Office365ApiClient(clientId, clientSecret, tenantId, scope, provisionerName, grouperO365FolderName, azurePrefix, azureSuffix, grouperSession);
     }
 
     @Override
@@ -151,7 +150,7 @@ public class Office365ChangeLogConsumer extends ChangeLogConsumerBaseImpl {
     private void scheduleFullSyncOfGroup(Group group) {
         if (!lastScheduledMap.containsKey(group.getName()) || lastScheduledMap.get(group.getName()) < System.currentTimeMillis()) {
             Map<String, Object> debugMap = new LinkedHashMap<String, Object>();
-            scheduledExecutorService.schedule(new O365SingleFullGroupSync(debugMap, group, 0, 0, 0, 0, GrouperO365Utils.configSourcesForSubjects(), GrouperO365Utils.configSubjectAttributeForO365Username()), 30, TimeUnit.MINUTES);
+            scheduledExecutorService.schedule(new O365SingleFullGroupSync(debugMap, group, 0, 0, 0, 0, GrouperO365Utils.configSourcesForSubjects(), GrouperO365Utils.configSubjectAttributeForO365Username(), apiClient.provisionerName), 30, TimeUnit.MINUTES);
             lastScheduledMap.put(group.getName(), System.currentTimeMillis() + scheduleBuffer);// prevent lots of full syncs from happening.
         }
     }

--- a/src/main/java/edu/ksu/ome/o365/grouper/O365SingleFullGroupSync.java
+++ b/src/main/java/edu/ksu/ome/o365/grouper/O365SingleFullGroupSync.java
@@ -11,8 +11,6 @@ import edu.internet2.middleware.grouper.changeLog.consumer.model.Members;
 import edu.internet2.middleware.grouper.changeLog.consumer.model.User;
 import edu.internet2.middleware.subject.Subject;
 import edu.internet2.middleware.subject.SubjectNotFoundException;
-import edu.internet2.middleware.subject.provider.LdapSubject;
-import edu.internet2.middleware.subject.provider.SubjectImpl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,9 +32,11 @@ public class O365SingleFullGroupSync implements Runnable {
     private String subjectAttributeForO365Username;
     private String tenantId;
 
+    private String name;
+
     private Office365ApiClient apiClient;
 
-    public O365SingleFullGroupSync(Map<String, Object> debugMap, Group grouperGroup, int insertCount, int deleteCount, int unresolvableCount, int totalCount, Set<String> sourcesForSubjects, String subjectAttributeForO365Username) {
+    public O365SingleFullGroupSync(Map<String, Object> debugMap, Group grouperGroup, int insertCount, int deleteCount, int unresolvableCount, int totalCount, Set<String> sourcesForSubjects, String subjectAttributeForO365Username, String name) {
         this.debugMap = debugMap;
         this.grouperGroup = grouperGroup;
         this.insertCount = insertCount;

--- a/src/main/java/edu/ksu/ome/o365/grouper/O365SingleFullGroupSync.java
+++ b/src/main/java/edu/ksu/ome/o365/grouper/O365SingleFullGroupSync.java
@@ -45,11 +45,12 @@ public class O365SingleFullGroupSync implements Runnable {
         this.totalCount = totalCount;
         this.sourcesForSubjects = sourcesForSubjects;
         this.subjectAttributeForO365Username = subjectAttributeForO365Username;
+        this.name = name;
         setupApiClient();
     }
 
     protected void setupApiClient() {
-        Office365ChangeLogConsumer temp = new Office365ChangeLogConsumer();
+        Office365ChangeLogConsumer temp = new Office365ChangeLogConsumer(name);
         apiClient = temp.getApiClient();
         tenantId = temp.getTenantId();
     }

--- a/src/main/java/edu/ksu/ome/o365/grouper/Office365FullRefresh.java
+++ b/src/main/java/edu/ksu/ome/o365/grouper/Office365FullRefresh.java
@@ -7,9 +7,6 @@ import edu.internet2.middleware.grouper.app.loader.GrouperLoaderScheduleType;
 import edu.internet2.middleware.grouper.app.loader.GrouperLoaderStatus;
 import edu.internet2.middleware.grouper.app.loader.GrouperLoaderType;
 import edu.internet2.middleware.grouper.app.loader.db.Hib3GrouperLoaderLog;
-import edu.internet2.middleware.grouper.attr.AttributeDefName;
-import edu.internet2.middleware.grouper.attr.assign.AttributeAssign;
-import edu.internet2.middleware.grouper.attr.finder.AttributeDefNameFinder;
 import edu.internet2.middleware.grouper.changeLog.consumer.GrouperO365Utils;
 import edu.internet2.middleware.grouper.changeLog.consumer.Office365ApiClient;
 import edu.internet2.middleware.grouper.changeLog.consumer.Office365ChangeLogConsumer;
@@ -69,7 +66,7 @@ public class Office365FullRefresh extends OtherJobBase {
 
     public  void fullRefreshLogic(OtherJobInput otherJobInput) {
         GrouperSession grouperSession = otherJobInput.getGrouperSession();
-        Office365ChangeLogConsumer temp = new Office365ChangeLogConsumer(otherJobInput,name);
+        Office365ChangeLogConsumer temp = new Office365ChangeLogConsumer(name);
         apiClient = temp.getApiClient();
         Map<String, Object> debugMap = new LinkedHashMap<String, Object>();
 
@@ -147,7 +144,7 @@ public class Office365FullRefresh extends OtherJobBase {
             grouperGroups = reloadGrouperGroup(grouperO365Folder, grouperGroups);
 
             for (Group group : grouperGroups) {
-                O365SingleFullGroupSync o365SingleFullGroupSync = new O365SingleFullGroupSync(debugMap, group, insertCount, deleteCount, unresolvableCount, totalCount, sourcesForSubjects, subjectAttributeForO365Username).invoke();
+                O365SingleFullGroupSync o365SingleFullGroupSync = new O365SingleFullGroupSync(debugMap, group, insertCount, deleteCount, unresolvableCount, totalCount, sourcesForSubjects, subjectAttributeForO365Username, name).invoke();
                 insertCount = o365SingleFullGroupSync.getInsertCount();
                 deleteCount = o365SingleFullGroupSync.getDeleteCount();
                 unresolvableCount = o365SingleFullGroupSync.getUnresolvableCount();

--- a/src/test/java/edu/ksu/ome/o365/grouper/O365SingleFullGroupSyncUTest.java
+++ b/src/test/java/edu/ksu/ome/o365/grouper/O365SingleFullGroupSyncUTest.java
@@ -151,7 +151,7 @@ public class O365SingleFullGroupSyncUTest {
 
     private class O365SingleFullGroupSyncMock extends O365SingleFullGroupSync {
         public O365SingleFullGroupSyncMock(Map<String, Object> debugMap, Group grouperGroup, int insertCount, int deleteCount, int unresolvableCount, int totalCount, Set<String> sourcesForSubjects, String subjectAttributeForO365Username) {
-            super(debugMap, grouperGroup, insertCount, deleteCount, unresolvableCount, totalCount, sourcesForSubjects, subjectAttributeForO365Username);
+            super(debugMap, grouperGroup, insertCount, deleteCount, unresolvableCount, totalCount, sourcesForSubjects, subjectAttributeForO365Username, "o365");
         }
 
         @Override


### PR DESCRIPTION
Fix issue with provisioner.
Since there are now 'multiple' names, the initialization of the classes needed to perform full syncs of groups
fails due to missing configuration needed to determine the correct properties for initialization
This corrects that issue.